### PR TITLE
getAllRepos should work again

### DIFF
--- a/server/services/callGithub.ts
+++ b/server/services/callGithub.ts
@@ -1,62 +1,67 @@
-import { sampleCommitSummary } from "../data/dummyData"
-import { CommitSummary } from "../types/CommitSummary"
-import { sampleCommits } from "../data/sampleCommits"
-import { AppConfig } from "../config/AppConfig"
-import dotenv from "dotenv"
-import { getAllRepos } from "./getRepos"
+import { sampleCommitSummary } from "../data/dummyData";
+import { CommitSummary } from "../types/CommitSummary";
+import { sampleCommits } from "../data/sampleCommits";
+import { AppConfig } from "../config/AppConfig";
+import dotenv from "dotenv";
+import { getAllRepos } from "./getRepos";
 
-dotenv.config()
+dotenv.config();
 
-const usernames: string[] = ["yablochko8", "dxren", "fractal-bootcamp", "dcsan"]
+const usernames: string[] = [
+  "yablochko8",
+  "dxren",
+  "fractal-bootcamp",
+  "dcsan",
+];
 
-export const gitHubToken = process.env.GITHUB_AUTH_KEY
+export const gitHubToken = process.env.GITHUB_AUTH_KEY;
 
 const getRecentCommitList = async (
   repoName: string,
-  timeSpan: number = 4
+  timeSpan: number = 12
 ): Promise<string[]> => {
   // take timeSpan value in HOURS
   // convert it to milliseconds
   const sinceDate = new Date(
     Date.now() - timeSpan * 60 * 60 * 1000
-  ).toISOString()
-  const githubUrl = `https://api.github.com/repos/${repoName}/commits?since=${sinceDate}`
+  ).toISOString();
+  const githubUrl = `https://api.github.com/repos/${repoName}/commits?since=${sinceDate}`;
 
   try {
     const response = await fetch(githubUrl, {
       headers: {
         Authorization: `Bearer ${gitHubToken}`,
       },
-    })
+    });
     if (!response.ok) {
       console.error(
         "FAILED TO GET RESPONSE FROM GITHUB: " + response.statusText
-      )
+      );
       throw new Error(
         "FAILED TO GET RESPONSE FROM GITHUB: " + response.statusText
-      )
+      );
     }
-    const commits = await response.json()
-    return commits.map((commit) => commit.sha)
+    const commits = await response.json();
+    return commits.map((commit) => commit.sha);
   } catch (error) {
-    console.error("ERROR: could not parse commits from response", error)
-    return []
+    console.error("ERROR: could not parse commits from response", error);
+    return [];
   }
-}
+};
 
 const parseCommitInfo = (
   commitData: any,
   ownerSlashRepo: string
 ): CommitSummary => {
-  const filesChanged = commitData.files.length
+  const filesChanged = commitData.files.length;
   const linesAdded = commitData.files.reduce(
     (sum: number, file: any) => sum + file.additions,
     0
-  )
+  );
   const linesRemoved = commitData.files.reduce(
     (sum: number, file: any) => sum + file.deletions,
     0
-  )
+  );
 
   const returnObj: CommitSummary = {
     user: commitData.commit.author.name,
@@ -68,57 +73,57 @@ const parseCommitInfo = (
     filesChangedNum: filesChanged,
     filesChangedNames: commitData.files.map((file) => file.filename).join(", "),
     // actualChanges: add in later
-  }
+  };
 
-  return returnObj
-}
+  return returnObj;
+};
 
 const getCommitSummary = async (
   commitId: string,
   ownerSlashRepo: string
 ): Promise<CommitSummary> => {
-  const commitUrl = `https://api.github.com/repos/${ownerSlashRepo}/commits/${commitId}`
+  const commitUrl = `https://api.github.com/repos/${ownerSlashRepo}/commits/${commitId}`;
 
   try {
-    const response = await fetch(commitUrl)
+    const response = await fetch(commitUrl);
     if (!response.ok) {
-      console.error("ERROR GETTING COMMIT INFO", { response })
-      throw new Error("ERROR GETTING COMMIT INFO")
+      console.error("ERROR GETTING COMMIT INFO", { response });
+      throw new Error("ERROR GETTING COMMIT INFO");
     }
-    const commitData = await response.json()
-    return parseCommitInfo(commitData, ownerSlashRepo)
+    const commitData = await response.json();
+    return parseCommitInfo(commitData, ownerSlashRepo);
   } catch (error) {
-    console.error("Error fetching commit summary", { error, ownerSlashRepo })
-    return sampleCommitSummary
+    console.error("Error fetching commit summary", { error, ownerSlashRepo });
+    return sampleCommitSummary;
   }
-}
+};
 
 export type CommitOpts = {
-  mock: boolean
-}
+  mock: boolean;
+};
 
 export const getRecentCommits = async (): Promise<CommitSummary[]> => {
   if (AppConfig.mock) {
-    console.warn("Using mock data")
-    return sampleCommits
+    console.warn("Using mock data");
+    return sampleCommits;
   }
 
-  const arrayOfRepos = await getAllRepos(usernames)
+  const arrayOfRepos = await getAllRepos(usernames);
   // const arrayOfRepos = ["fractal-bootcamp/hackathon-kitchen-gossip"];
 
-  const commitSummaries: CommitSummary[] = []
+  const commitSummaries: CommitSummary[] = [];
 
   for (const ownerSlashRepo of arrayOfRepos) {
-    const commitIds = await getRecentCommitList(ownerSlashRepo)
+    const commitIds = await getRecentCommitList(ownerSlashRepo);
 
     for (const commit of commitIds) {
-      const newSummary = await getCommitSummary(commit, ownerSlashRepo)
-      commitSummaries.push(newSummary)
+      const newSummary = await getCommitSummary(commit, ownerSlashRepo);
+      commitSummaries.push(newSummary);
     }
   }
-  console.log("commitSummaries", commitSummaries)
-  return commitSummaries
-}
+  console.log("commitSummaries", commitSummaries);
+  return commitSummaries;
+};
 
 // const pleaseWork = await getRecentCommits();
 // console.log(pleaseWork);

--- a/server/services/getRepos.ts
+++ b/server/services/getRepos.ts
@@ -16,7 +16,7 @@ const getOneUserRepos = async (username: string): Promise<string[]> => {
     const response = await fetch(url, headerObject);
 
     if (!response.ok) {
-      throw new Error("you suck");
+      throw new Error("Failed to fetch repositories for user: ${username}");
     }
     const repos = await response.json();
     return repos

--- a/server/services/getRepos.ts
+++ b/server/services/getRepos.ts
@@ -1,12 +1,17 @@
 import { gitHubToken } from "./callGithub";
 
 const getOneUserRepos = async (username: string): Promise<string[]> => {
-  const url = `https://api.github.com/users/${username}/repos`;
+  const url = `https://api.github.com/users/${username}/repos?sort=updated`;
   const headerObject = {
     headers: {
       Authorization: `Bearer ${gitHubToken}`,
     },
   };
+
+  const twelveHoursAgo = new Date(
+    Date.now() - 12 * 60 * 60 * 1000
+  ).toISOString();
+
   try {
     const response = await fetch(url, headerObject);
 
@@ -14,7 +19,11 @@ const getOneUserRepos = async (username: string): Promise<string[]> => {
       throw new Error("you suck");
     }
     const repos = await response.json();
-    return repos.map((repo) => repo.full_name);
+    return repos
+      .filter(
+        (repo) => new Date(repo.updated_at).toISOString() > twelveHoursAgo
+      )
+      .map((repo) => repo.full_name);
   } catch (error) {
     console.log("ERRROR: problems here", error);
     return [];
@@ -30,6 +39,6 @@ export const getAllRepos = async (usernames: string[]): Promise<string[]> => {
   return outputArray;
 };
 
-// const testData = await getAllRepos(["yablochko8", "fractal-bootcamp"]);
+const testData = await getAllRepos(["yablochko8", "fractal-bootcamp"]);
 
-// console.log(testData);
+console.log(testData);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit adbae7d78cdc8bbf21095e7f6a66211e3ce6b098  | 
|--------|--------|

### Summary:
Fixed `getAllRepos` to fetch repositories updated within the last 12 hours and adjusted commit fetching logic.

**Key points**:
- Updated `server/services/callGithub.ts` to adjust the `timeSpan` parameter in `getRecentCommitList` from 4 to 12 hours.
- Modified `getRecentCommitList` to handle errors and log them appropriately.
- Updated `server/services/getRepos.ts` to filter repositories updated within the last 12 hours in `getOneUserRepos`.
- Added sorting by updated time in the GitHub API request URL in `getOneUserRepos`.
- Ensured `getAllRepos` correctly aggregates repositories from multiple users.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->